### PR TITLE
fix: use CLDR gettext_locale_name for correct Gettext locale mapping

### DIFF
--- a/lib/localise/localise.ex
+++ b/lib/localise/localise.ex
@@ -123,8 +123,20 @@ defmodule Bonfire.Common.Localise do
     # change Cldr locale
     Bonfire.Common.Localise.Cldr.put_locale(locale)
 
+    # Resolve the correct Gettext locale name from the CLDR locale tag.
+    # CLDR uses BCP47 format (e.g. "zh-TW") while Gettext uses POSIX format (e.g. "zh_TW").
+    # Without this mapping, locales like zh-Hant/zh-TW won't find their Gettext translations.
+    gettext_locale =
+      case Bonfire.Common.Localise.Cldr.validate_locale(locale) do
+        {:ok, %{gettext_locale_name: name}} when not is_nil(name) ->
+          to_string(name)
+
+        _ ->
+          to_string(locale)
+      end
+
     # Sets the global Gettext locale for the current process.
-    Gettext.put_locale(to_string(locale))
+    Gettext.put_locale(gettext_locale)
 
     # change Gettext locale
     # Gettext.put_locale(Bonfire.Common.Localise.Gettext, to_string(locale))


### PR DESCRIPTION
## Problem

When a user selects a locale with a regional subtag (e.g. `zh-Hant` for Traditional Chinese) from the language switcher, the UI does not actually change language and falls back to English.

### Root Cause

`put_locale/1` passes the CLDR locale name directly to `Gettext.put_locale/1`:

```elixir
# Before
Gettext.put_locale(to_string(locale))  # sets "zh-TW" (BCP47 format)
```

But Gettext expects POSIX format locale names (e.g. `zh_TW` with underscore, not `zh-TW` with hyphen). Since Gettext doesn't recognize `zh-TW`, it can't find the translation files under `priv/localisation/zh_TW/` and falls back to the default locale.

This affects all locales with regional subtags: `zh-Hant`→`zh_TW`, `zh-Hant-HK`→`zh_HK`, `pt-BR`, `fr-CA`, `en-GB`, etc.

### Why HTTP requests work but LiveView doesn't

`Cldr.Plug.SetLocale` (used for HTTP requests) correctly resolves the Gettext locale name from the CLDR `LanguageTag` struct's `gettext_locale_name` field. However, when LiveView mounts, it goes through `put_best_locale_match/3` → `put_locale/1`, which bypasses this mapping.

### Verification

```elixir
{:ok, tag} = Bonfire.Common.Localise.Cldr.validate_locale("zh-Hant")
tag.gettext_locale_name  #=> "zh_TW"  ← correct mapping exists in CLDR!

# But put_locale was doing:
Gettext.put_locale("zh-TW")  #=> Gettext can't find this locale
```

## Fix

Resolve the correct Gettext locale name via `Cldr.validate_locale/1` before setting it:

```elixir
# After
case Bonfire.Common.Localise.Cldr.validate_locale(locale) do
  {:ok, %{gettext_locale_name: name}} when not is_nil(name) ->
    Gettext.put_locale(to_string(name))  # sets "zh_TW" (POSIX format) ✅
  _ ->
    Gettext.put_locale(to_string(locale))  # fallback for unknown locales
end
```

## Testing

Tested with Bonfire 1.0.2-alpha.34 Docker image:

| Locale | Before | After |
|--------|--------|-------|
| `zh-Hant` (Traditional Chinese) | ❌ Falls back to English | ✅ Shows 繁體中文 |
| `zh` (Chinese) | ✅ Works | ✅ Works |
| `pt-BR` (Brazilian Portuguese) | ❌ Falls back to English | ✅ Shows Português |
| `en` | ✅ Works | ✅ Works |

Related: bonfire-networks/bonfire-app#1837 (zh_TW translation PR)