### PR TITLE
fix: use CLDR gettext_locale_name for correct Gettext locale mapping

### DIFF
--- a/lib/localise/localise.ex
+++ b/lib/localise/localise.ex
@@ -123,8 +123,20 @@ defmodule Bonfire.Common.Localise do
     # change Cldr locale
     Bonfire.Common.Localise.Cldr.put_locale(locale)
 
+    # Resolve the correct Gettext locale name from the CLDR locale tag.
+    # CLDR uses BCP47 format (e.g. "zh-TW") while Gettext uses POSIX format (e.g. "zh_TW").
+    # Without this mapping, locales like zh-Hant/zh-TW won't find their Gettext translations.
+    gettext_locale =
+      case Bonfire.Common.Localise.Cldr.validate_locale(locale) do
+        {:ok, %{gettext_locale_name: name}} when not is_nil(name) ->
+          to_string(name)
+
+        _ ->
+          to_string(locale)
+      end
+
     # Sets the global Gettext locale for the current process.
-    Gettext.put_locale(to_string(locale))
+    Gettext.put_locale(gettext_locale)
 
     # change Gettext locale
     # Gettext.put_locale(Bonfire.Common.Localise.Gettext, to_string(locale))


### PR DESCRIPTION
## Fix

Resolves bonfire-networks/bonfire-app#1838

`put_locale/1` now resolves the correct Gettext locale name via `Cldr.validate_locale/1` before setting it, ensuring CLDR format (BCP47, e.g. `zh-TW`) is correctly mapped to Gettext format (POSIX, e.g. `zh_TW`).

### Before
```elixir
Gettext.put_locale(to_string(locale))  # "zh-TW" → Gettext can't find translations
```

### After
```elixir
case Bonfire.Common.Localise.Cldr.validate_locale(locale) do
  {:ok, %{gettext_locale_name: name}} when not is_nil(name) ->
    Gettext.put_locale(to_string(name))  # "zh_TW" → translations found ✅
  _ ->
    Gettext.put_locale(to_string(locale))  # fallback for unknown locales
end
```

### Tested

Runtime hot-patched on Bonfire 1.0.2-alpha.34 Docker (aarch64), Elixir 1.19.5, OTP 28:

| Locale | Before | After |
|--------|--------|-------|
| `zh-Hant` → Gettext | `zh-TW` ❌ | `zh_TW` ✅ |
| `zh` → Gettext | `zh` ✅ | `zh` ✅ |
| `en` → Gettext | `en` ✅ | `en` ✅ |
| `pt-BR` → Gettext | `pt-BR` ❌ | `pt_BR` ✅ |

User-verified: Traditional Chinese UI correctly displays after fix (Settings: 個人資料, 帳號, 偏好設定, etc.)

Related: bonfire-networks/bonfire-app#1838, bonfire-networks/bonfire-app#1837