### PR TITLE
test: harden lightweight Bonfire setup

### DIFF
--- a/lib/repo/test_instance_repo.ex
+++ b/lib/repo/test_instance_repo.ex
@@ -87,7 +87,7 @@ defmodule Bonfire.Common.TestInstanceRepo do
 
     repo.put_dynamic_repo(repo)
 
-    if Boruta.Config.repo() != repo, do: Config.put([Boruta.Oauth, :repo], repo)
+    if boruta_repo() != repo, do: Config.put([Boruta.Oauth, :repo], repo)
 
     configured_repo = Config.repo()
 
@@ -96,7 +96,7 @@ defmodule Bonfire.Common.TestInstanceRepo do
         do: debug("switching from repo #{configured_repo} to #{repo}"),
         else: debug("repo already set to #{repo}")
 
-      if Boruta.Config.repo() != repo, do: err(Boruta.Config.repo(), "wrong boruta repo")
+      if boruta_repo() && boruta_repo() != repo, do: err(boruta_repo(), "wrong boruta repo")
 
       if configured_repo != repo, do: err(configured_repo, "wrong repo")
     end
@@ -125,7 +125,13 @@ defmodule Bonfire.Common.TestInstanceRepo do
         do: debug("switching from repo #{configured_repo} to #{repo}"),
         else: debug("repo already set to #{repo}")
 
-      if Boruta.Config.repo() != repo, do: err(Boruta.Config.repo(), "wrong boruta repo")
+      if boruta_repo() && boruta_repo() != repo, do: err(boruta_repo(), "wrong boruta repo")
+    end
+  end
+
+  defp boruta_repo do
+    if Code.ensure_loaded?(Boruta.Config) and function_exported?(Boruta.Config, :repo, 0) do
+      Boruta.Config.repo()
     end
   end
 

--- a/lib/runtime_config.ex
+++ b/lib/runtime_config.ex
@@ -152,9 +152,10 @@ defmodule Bonfire.Common.RuntimeConfig do
         slow_query_ms: 500,
         queue_target: 5_000,
         queue_interval: 2_000,
-        timeout: 50_000,
+        timeout: System.get_env("DB_QUERY_TIMEOUT", "50000") |> String.to_integer(),
         connect_timeout: 10_000,
-        ownership_timeout: 100_000,
+        ownership_timeout:
+          System.get_env("DB_OWNERSHIP_TIMEOUT", "100000") |> String.to_integer(),
         # Increase pool size for CI to handle concurrent tests - force minimum of 20 for tests
         pool_size: max(pool_size, 20),
         log: false,

--- a/test/support/nebulex_cache_test.ex
+++ b/test/support/nebulex_cache_test.ex
@@ -1,6 +1,6 @@
 # Nebulex dependency path
 nbx_dep_path = Mix.Project.deps_paths()[:nebulex]
-test_path = Path.dirname(__ENV__.file)
+_test_path = Path.dirname(__ENV__.file)
 
 if File.exists?("#{nbx_dep_path}/test/") do
   for file <- File.ls!("#{nbx_dep_path}/test/support"), file != "test_cache.ex" do
@@ -21,5 +21,5 @@ if File.exists?("#{nbx_dep_path}/test/") do
   #   Code.require_file("#{test_path}/cache_support/" <> file, __DIR__)
   # end
 else
-  IO.warn("You need to clone the nebulex dep to run its tests")
+  :ok
 end


### PR DESCRIPTION
## Summary

Part 1 of the Bonfire feed query performance stack for bonfire-networks/bounties#1.

This prepares the lightweight test setup used by the benchmark/regression harness:

- Guard the optional Boruta config lookup in `Bonfire.Common.TestInstanceRepo`.
- Add test-runtime DB timeout knobs for strict local benchmark runs.
- Keep the Nebulex cache test helper warning-free.

## Stack

1. bonfire_common: https://github.com/bonfire-networks/bonfire_common/pull/15
2. bonfire_data_social: https://github.com/bonfire-networks/bonfire_data_social/pull/5
3. bonfire_social: https://github.com/bonfire-networks/bonfire_social/pull/7
4. bonfire_ui_social: https://github.com/bonfire-networks/bonfire_ui_social/pull/9
5. bonfire-app: https://github.com/bonfire-networks/bonfire-app/pull/1994

## Why

The strict local benchmark stack runs Bonfire sibling extensions through a lightweight test app. Optional runtime modules should not prevent the harness from starting before feed-query behavior can be tested.

## Validation

Stack-level validation was run from `bonfire-app` after applying the sibling branches:

```bash
BONFIRE_FULL_RENDER_HIDDEN_MULTIPLIER=128 BONFIRE_FULL_RENDER_HIDDEN_EXTRA_ROWS=25 ./test-pagination-regression.sh all-with-strict-benchmark
```

Result: passed locally in about 15.2 minutes.

Additional local checks:

- `git diff --check origin/main..HEAD`
- Included in the app-level format target for the feed pagination harness.

## Known Limits

I do not have the campground database or maintainer hardware, so I am not claiming the official `feed_backend` benchmark has passed. That still needs maintainer verification on campground.
